### PR TITLE
Eliminate duplicate page request

### DIFF
--- a/controller.html
+++ b/controller.html
@@ -39,7 +39,7 @@
           return false;
         });
 
-        $("ul").click((e) => {
+        $("ul#list").click((e) => {
           let targetEle = $(e.target);
           if (targetEle.is("small")) {
             targetEle = targetEle.parent();


### PR DESCRIPTION
When clicking on the child ul element, an event was thrown for both the child and the parent container. With the specification of the selector, only one event is thrown for the "ul#list" container. Closes #1 